### PR TITLE
remove useIsMobile from LegacyHeader and use css instead due to CLS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,8 @@ jobs:
       - restore_cache: *restore_js_packages
 
       - run:
-          name: npm ci --unsafe-perm
-          command: npm ci --unsafe-perm
+          name: npm ci --unsafe-perm --legacy-peer-deps
+          command: npm ci --unsafe-perm --legacy-peer-deps
           no_output_timeout: 20m
 
       - run: |

--- a/packages/components/src/LegacyHeader/LegacyHeader.tsx
+++ b/packages/components/src/LegacyHeader/LegacyHeader.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { color } from 'styled-system';
 
 import { Box } from '../Box';
-import useIsMobile from '../hooks/useIsMobile';
 import { LegacyUserMenuProps } from '../LegacyUserMenu';
 import { TagNavTagsType } from './components/LegacyTagNav';
 import { LegacyDesktopHeader } from './LegacyDesktopHeader';
@@ -58,33 +57,32 @@ export const LegacyHeader: React.FC<LegacyHeaderProps> = ({
   showAds,
   adsPreview,
 }) => {
-  const isMobile = useIsMobile();
-
-  if (isMobile) {
-    return (
-      <LegacyMobileHeader
-        user={user}
-        headerCampaignUrl={headerCampaignUrl}
-        headerCampaignImageMobile={headerCampaignImageMobile}
-        newsIndicator={newsIndicator}
-        proIndicator={proIndicator}
-      />
-    );
-  }
-
   return (
-    <LegacyDesktopHeader
-      user={user}
-      userMenuLabelUrl={userMenuLabelUrl}
-      userMenuLinkGroups={userMenuLinkGroups}
-      tags={tags}
-      tagsLoading={tagsLoading}
-      headerCampaignUrl={headerCampaignUrl}
-      headerCampaignImage={headerCampaignImage}
-      newsIndicator={newsIndicator}
-      proIndicator={proIndicator}
-      showAds={showAds}
-      adsPreview={adsPreview}
-    />
+    <>
+      <Box display={['block', 'block', 'none']}>
+        <LegacyMobileHeader
+          user={user}
+          headerCampaignUrl={headerCampaignUrl}
+          headerCampaignImageMobile={headerCampaignImageMobile}
+          newsIndicator={newsIndicator}
+          proIndicator={proIndicator}
+        />
+      </Box>
+      <Box display={['none', 'none', 'block']}>
+        <LegacyDesktopHeader
+          user={user}
+          userMenuLabelUrl={userMenuLabelUrl}
+          userMenuLinkGroups={userMenuLinkGroups}
+          tags={tags}
+          tagsLoading={tagsLoading}
+          headerCampaignUrl={headerCampaignUrl}
+          headerCampaignImage={headerCampaignImage}
+          newsIndicator={newsIndicator}
+          proIndicator={proIndicator}
+          showAds={showAds}
+          adsPreview={adsPreview}
+        />
+      </Box>
+    </>
   );
 };


### PR DESCRIPTION
Schön ist das alles nicht, ich weiß. Dadurch werden jetzt natürlich immer beide Header (& Footer) ins DOM geschrieben.

**Problem vorher:** Dadurch, dass das useIsMobile erst clientseitig ausgeführt wird und demnach erst mal false ist und dann die Desktop-Variante ausgegeben wurde, entstand CLS. 

**Andere Lösungsansätze:** Hier die t3n-mobile-Cookie-Lösung (HTTP_X_T3N_LAYOUT_MODE) einzubauen ergibt mMn wenig Sinn: Großer Aufwand für etwas, dass wir perspektivisch loswerden wollen. Daher jetzt einfach so. Diese Lösung nutzen wir so auch schon im LegacyFooter.

Für mich ist das okay so und ich glaube, dass es eher ein geringes Problem ist, zu viel im DOM zu haben. Schön geht natürlich anders, aber ja. Falls ihr da komplett anderer Meinung seid, sollten wir dafür ein Ticket schreiben, diesen Stand aber erst mal so live spielen wegen des CLS und unseres guten Freundes Google 😁 
