### PR TITLE
ci: Fix prerelease versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       # "echo -n ${CIRCLE_BRANCH} | sha256sum | cut -c -10" command creates a short hash of the current branch name
-      - run: ./node_modules/.bin/lerna publish prepatch --dist-tag prerelease-$(echo -n ${CIRCLE_BRANCH} | sha256sum | cut -c -10) --preid prerelease-$(echo -n ${CIRCLE_BRANCH} | sha256sum | cut -c -10) --ignore-scripts --no-git-reset --yes
+      - run: ./node_modules/.bin/lerna publish prerelease --dist-tag prerelease-$(echo -n ${CIRCLE_BRANCH} | sha256sum | cut -c -10) --preid prerelease-$(echo -n ${CIRCLE_BRANCH} | sha256sum | cut -c -10) --ignore-scripts --no-git-reset --yes
 
 workflows:
   version: 2


### PR DESCRIPTION
## Changes
* Fixes versioning of prereleases so instead of raising the patch version, only the prerelease version gets raised, e.g. `0.8.1-prerelease-415c5d6a64.0 => 0.8.1-prerelease-415c5d6a64.1`

## Checklist
- [x] Codestyle-Kriterien sind erfüllt
- [ ] Code Review hat stattgefunden
- [x] Tests (wenn sinnvoll) sind geschrieben
- [x] Code ist dokumentiert sofern erforderlich
