### PR TITLE
add z-index on wrapper in pagelayout

### DIFF
--- a/packages/components/src/LegacyPageLayout/LegacyPageLayout.tsx
+++ b/packages/components/src/LegacyPageLayout/LegacyPageLayout.tsx
@@ -16,6 +16,8 @@ export interface LegacyPageLayoutProps extends LegacyHeaderProps {
 
 const Wrapper = styled(Box)`
   ${({ theme }) => color({ theme, bg: 'background.primary' })}
+  position: relative;
+  z-index: 150;
 `;
 
 const LegacyPageLayout: React.FC<LegacyPageLayoutProps> = ({


### PR DESCRIPTION
## Changes
* add wrapper z-index to overlay wallpaper ads

According to https://github.com/t3n/styleguide-t3n-rebrush/commit/6d7361687b8a20546e87bc71cfab8c9281a95fd7

## Checklist
- [x] JIRA-Ticket ist verlinkt
- [x] Codestyle-Kriterien sind erfüllt
- [ ] Code Review hat stattgefunden
- [x] Tests (wenn sinnvoll) sind geschrieben
- [x] Code ist dokumentiert sofern erforderlich
  
Resolves [GREEN-1180](https://yeebase.atlassian.net/browse/GREEN-1180)


[GREEN-1180]: https://yeebase.atlassian.net/browse/GREEN-1180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ